### PR TITLE
Correct default flavor size

### DIFF
--- a/flavors.yaml
+++ b/flavors.yaml
@@ -21,7 +21,7 @@ nodeGroupDefaults:
   # Indicates if the node group should be autoscaled
   autoscale: false
   # The flavor to use for machines in the node group
-  machineFlavor: l3.small
+  machineFlavor: l3.micro
 
   healthCheck:
     # Indicates if the machine health check should be enabled


### PR DESCRIPTION
In the previous commit, this was changed because the 8GB + 50GB RAM/Disk respectively made it a bit tight for most workloads. I was meant to go one step up (tiny @ 16/100), but instead went to small which is 128GB RAM per machine.

This meant, to deploy a cluster, the user would need 0.5TB of RAM...let's adjust it back to something sensible