### PR TITLE
Enable Monitoring by default

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -170,3 +170,10 @@ apiServer:
   associateFloatingIP: true
   # The port to use for the API server
   port: 6443
+
+addons:
+  # Enable monitoring by default, this deploys
+  # https://github.com/stackhpc/capi-helm-charts/blob/main/charts/cluster-addons/README.md#monitoring-and-logging
+  # and includes Loki which is required for central logging as per UKRI policy
+  monitoring:
+    enabled: true


### PR DESCRIPTION
This enables deploying the Monitoring stack by default. This includes Loki which will allow us to forward stdout/err onto our centralised logging.

By default the stack will deploy with a ClusterIP configuration, so will not be available outside the cluster (except for using kubectl port-forward) unless the user explicitly makes it available.