### PR TITLE
Remove null 'global' block

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -1,4 +1,3 @@
-global:
 # The PEM-encoded CA certificate for openstack.stfc.ac.uk
 # this expires 2023-12-05T23:59:59Z (UTC)
 # This allows a user to skip adding verify: false


### PR DESCRIPTION
Removes an empty global block which effectively nulled out the section from upstream, including imagePrefix.

This would result in the following error attempting to upgrade: 
```Error: template: openstack-cluster/templates/autoscaler/deployment.yaml:26:20: executing "openstack-cluster/templates/autoscaler/deployment.yaml" at <include "openstack-cluster.autoscaler.image" .>: error calling include: template: openstack-cluster/templates/_helpers.tpl:156:64: executing "openstack-cluster.autoscaler.image" at <.Values.global.imagePrefix>: nil pointer evaluating interface {}.imagePrefix```