### PR TITLE
Force availability zone to not use default for Cinder storage class

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -176,3 +176,8 @@ addons:
   # and includes Loki which is required for central logging as per UKRI policy
   monitoring:
     enabled: true
+  # set availabilty zone as upstream uses nova by default
+  openstack:
+    csiCinder:
+      storageClass:
+        availabilityZone: ceph


### PR DESCRIPTION
Upstream sets nova by default for Cinder CSI storage class. 
`values.yaml` has been updated to override the default availability zone and force a different availability zone to be used.