### PR TITLE
Edited flavour value to l3.nano from l3.micro to better reflect documentation.

### DIFF
--- a/flavors.yaml
+++ b/flavors.yaml
@@ -21,7 +21,7 @@ nodeGroupDefaults:
   # Indicates if the node group should be autoscaled
   autoscale: false
   # The flavor to use for machines in the node group
-  machineFlavor: l3.micro
+  machineFlavor: l3.nano
 
   healthCheck:
     # Indicates if the machine health check should be enabled


### PR DESCRIPTION
Documentation for cloud CAPI values hints that the default flavour for clusters is l3.nano yet actual value was l3.micro. Found it a bit troublesome when working on a smaller quota as machines refused to build as they were too large. Changed the value to l3.nano as the default to reflect documentation better and to better fit lower quota users.