### PR TITLE
K8s 1_27 image bump

### DIFF
--- a/flavors.yaml
+++ b/flavors.yaml
@@ -6,7 +6,7 @@ nodeGroups:
     # and is enabled by default
     name: default-md-0
     # The number of machines in the node group if autoscale is false
-    machineCount: 3
+    machineCount: 2
 
   # The following node groups are optional and can be enabled by uncommenting them
   # - name: md-l3-small

--- a/user-values.yaml
+++ b/user-values.yaml
@@ -20,9 +20,9 @@ controlPlane:
 # The Kubernetes version of the cluster
 # This should match the version of kubelet and kubeadm in the image
 # and will be automatically updated by us
-kubernetesVersion: "1.24.11"
+kubernetesVersion: "1.27.7"
 # The name of the image to use for cluster machines
-machineImage: capi-ubuntu-2004-kube-v1.24.11-2023-05-18
+machineImage: "capi-ubuntu-2004-kube-v1.27.7-2023-11-01"
 
 # Settings for node-level registry auth if using a private registry
 registryAuth:

--- a/user-values.yaml
+++ b/user-values.yaml
@@ -13,7 +13,7 @@ controlPlane:
   # The number of control plane machines to deploy
   # For high-availability, this should be greater than 1
   # For etcd quorum, it should be odd - usually 3, or 5 for very large clusters
-  machineCount: 3
+  machineCount: 5
   # The flavor to use for control plane machines
   machineFlavor: l3.nano
 


### PR DESCRIPTION
- Bump the version to the latest public image :tada: 
- Rejig the default counts of machine based on ops feedback and experience