### PR TITLE
Add ingress controller, disabled by default

### DIFF
--- a/user-values.yaml
+++ b/user-values.yaml
@@ -24,6 +24,19 @@ kubernetesVersion: "1.27.7"
 # The name of the image to use for cluster machines
 machineImage: "capi-ubuntu-2004-kube-v1.27.7-2023-11-01"
 
+addons:
+  # Ingress is preferred, as it allows you to use DNS to locate multiple
+  # services behind a single FIP, and makes TLS trivial
+  # see https://stfc.atlassian.net/wiki/spaces/CLOUDKB/pages/309854262/CAPI+Ingress
+  ingress:
+    enabled: false
+    nginx:
+      release:
+        values:
+          controller:
+            service:
+              loadBalancerIP: # "130.x.y.z"
+
 # Settings for node-level registry auth if using a private registry
 registryAuth:
   {}


### PR DESCRIPTION
Adds the config for the ingress controller, this will steer users to not allocate a FIP per service, makes TLS trivial (using certbot or similar) and avoids duplicating effort because we use the StackHPC charts.

This disabled by default, pending documentation and additional testing. But I want to ensure the correct values is captured whilst we're here.


---

To test:

- Deploy with this config
- Uninstall the cluster
- Set ingress to enabled, and set a FIP (one already in your project) in `user-values.yaml`, re deploy and check the LB comes up with said IP