### PR TITLE
BUG: Set storageclass to use ceph

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -176,5 +176,5 @@ addons:
   # set availabilty zone as upstream uses nova by default
   openstack:
     csiCinder:
-      storageClass:
+      defaultStorageClass:
         availabilityZone: ceph


### PR DESCRIPTION
There was a typo in values.yaml which meant ceph was not set as the default availability zone for the cinder-csi