### PR TITLE
MAINT: Address feedback on values

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -140,19 +140,14 @@ kubeNetwork:
   # internal net on 172.16.x.y
   pods:
     cidrBlocks:
-      - 10.0.0.0/12
+      - 10.0.0.0/13
   services:
     cidrBlocks:
-      - 10.7.0.0/13
+      - 10.8.0.0/13
   serviceDomain: cluster.local
 
 # Settings for the OpenStack networking for the cluster
 clusterNetworking:
-  # Custom nameservers to use for the hosts
-  dnsNameservers:
-    - 130.246.209.132
-    - 130.246.209.163
-    - 130.246.208.220
   externalNetworkId: External
 
 # Settings for registry mirrors


### PR DESCRIPTION
Addresses some points flagged for improvement for our default values:

- DNS should be picked up through the DHCP allocation on the VM
- The services and pod nets overlap, this could cause problems so segment it into two /13 addresses