### PR TITLE
Move to new CAPI version (v1.7.0)

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CLUSTER_CTL_VERSION="v1.6.2"
+CLUSTER_CTL_VERSION="v1.7.0"
 CAPO_ADDON_VERSION="0.5.0"
 
 # Check a clouds.yaml file exists in the same directory as the script
@@ -57,7 +57,7 @@ sudo microk8s enable dns
 
 echo "Initialising cluster-api OpenStack provider..."
 echo "If this fails you may need a GITHUB_TOKEN, see https://stfc.atlassian.net/wiki/spaces/CLOUDKB/pages/211878034/Cluster+API+Setup for details"
-clusterctl init --infrastructure openstack
+clusterctl init --infrastructure=openstack:v0.9.0
 
 
 echo "Importing required helm repos and packages"


### PR DESCRIPTION
also added new line to account for the fact the new CAPO version is currently not working.