### PR TITLE
MAINT: Bump minor version for clusterctl

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CLUSTER_CTL_VERSION="v1.7.0"
+CLUSTER_CTL_VERSION="v1.7.1"
 CAPO_ADDON_VERSION="0.5.0"
 
 # Check a clouds.yaml file exists in the same directory as the script


### PR DESCRIPTION
There's a 1.7.1 release, bump the minor version so users get the latest version