### PR TITLE
BUG: fixes issue with argocd OutofSync issues

### DIFF
--- a/user-values.yaml
+++ b/user-values.yaml
@@ -17,6 +17,11 @@ controlPlane:
   # The flavor to use for control plane machines
   machineFlavor: l3.nano
 
+  # defaults cause OutofSync issues in argocd
+  remediationStrategy:
+    retryPeriod: 20m0s
+    minHealthyPeriod: 1h0m0s
+
 # The Kubernetes version of the cluster
 # This should match the version of kubelet and kubeadm in the image
 # and will be automatically updated by us


### PR DESCRIPTION
There is an issue in argocd where it is expecting different things than what the defaults are

![image](https://github.com/stfc/cloud-capi-values/assets/81758831/adaf77fd-9693-4c1d-a6f4-5f11b16bc532)

So just add this as a quick fix 