### PR TITLE
MAINT: increase IP range

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -148,7 +148,7 @@ kubeNetwork:
 
 clusterNetworking:
   internalNetwork: 
-    nodeCidr: 192.168.0.0/16 
+    nodeCidr: 192.168.128.0/17
 
 # Settings for registry mirrors
 registryMirrors: { docker.io: ["https://dockerhub.stfc.ac.uk"] }

--- a/values.yaml
+++ b/values.yaml
@@ -146,6 +146,10 @@ kubeNetwork:
       - 10.8.0.0/13
   serviceDomain: cluster.local
 
+clusterNetworking:
+  internalNetwork: 
+    nodeCidr: 192.168.0.0/16 
+
 # Settings for registry mirrors
 registryMirrors: { docker.io: ["https://dockerhub.stfc.ac.uk"] }
 


### PR DESCRIPTION
running into issues where we run out of IPs for large clusters like jupyterhub.

since we provide a fully private network space for k8s we should be fine going to /16

we cap most users at 500 ports so it shouldn't cause issue to enable for everyone

NOTE: This does need to be tested - worth using this branch to spin up JupyterHub next time we need to.