### PR TITLE
Updated CAPI to newest version. (v1.8.1)

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CLUSTER_CTL_VERSION="v1.7.4"
+CLUSTER_CTL_VERSION="v1.8.1"
 CAPO_PROVIDER_VERSION="v0.10.4"
 CAPO_ADDON_VERSION="0.5.9"
 


### PR DESCRIPTION
Updated a line in the bootstrap script to download the newest version of CAPI (v1.8.1) after testing.