### PR TITLE
BUG: Reduce max unhealthy percentage

### DIFF
--- a/flavors.yaml
+++ b/flavors.yaml
@@ -29,7 +29,7 @@ nodeGroupDefaults:
     # The spec for the health check
     spec:
       # By default, unhealthy worker nodes are always remediated
-      maxUnhealthy: 100%
+      maxUnhealthy: 20%
       # If a node takes longer than 10 mins to startup, remediate it
       nodeStartupTimeout: 10m0s
       # By default, consider a worker node that has not been Ready for

--- a/flavors.yaml
+++ b/flavors.yaml
@@ -28,7 +28,7 @@ nodeGroupDefaults:
     enabled: true
     # The spec for the health check
     spec:
-      # By default, unhealthy worker nodes are always remediated
+      # By default, 20% unhealthy worker nodes remediated at a time
       maxUnhealthy: 20%
       # If a node takes longer than 10 mins to startup, remediate it
       nodeStartupTimeout: 10m0s
@@ -37,7 +37,7 @@ nodeGroupDefaults:
       unhealthyConditions:
         - type: Ready
           status: Unknown
-          timeout: 5m0s
+          timeout: 10m0s
         - type: Ready
           status: "False"
-          timeout: 5m0s
+          timeout: 10m0s

--- a/flavors.yaml
+++ b/flavors.yaml
@@ -29,6 +29,7 @@ nodeGroupDefaults:
     # The spec for the health check
     spec:
       # By default, 20% unhealthy worker nodes remediated at a time
+      # https://cluster-api.sigs.k8s.io/tasks/automated-machine-management/healthchecking#max-unhealthy
       maxUnhealthy: 20%
       # If a node takes longer than 10 mins to startup, remediate it
       nodeStartupTimeout: 10m0s


### PR DESCRIPTION
The default is dangerous as it can affect the cluster if it's running something like Longhorn and deletes all the nodes underneath it. Reduce the maxUnhealthy down to delete 1/5th at a time