### PR TITLE
Rework the while loop to not start it as a sub process

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -17,14 +17,14 @@ set_env_vars() {
     fi
     
     # Read each key-value pair from the JSON file
-    jq -r 'to_entries[] | .key + "=" + .value' "$json_file" | while IFS='=' read -r key value; do
+    while IFS='=' read -r key value; do
         # Sanitize the key to create a valid environment variable name
         env_var=$(sanitize_var_name "$key")
         
         # Set the environment variable
         export "$env_var"="$value"
         echo "Set $env_var=$value"
-    done
+    done < <(jq -r 'to_entries[] | .key + "=" + .value' "$json_file")
 }
 
 # Set environment variables from dependencies.json


### PR DESCRIPTION
After #31 it looks like the script is broken due to the env variables being set in outside of the main process, from the quick google it looks this is because of the variables being set in the sub processor and not in the main one. I am not very good with bash but I have changed the while loop a bit, and it looks like it works.

This is the error I had before my change: 
![image](https://github.com/user-attachments/assets/ff3d0ddc-e51d-4357-9296-f7a110e37bc7)

The script can be tested by adding echo on line 32 and commenting out everything below it. Without the change it will produce an unbound error, with the change it will correctly echo the version