### PR TITLE
DOC: Add note about valid names for nodeGroups

### DIFF
--- a/flavors.yaml
+++ b/flavors.yaml
@@ -2,6 +2,7 @@
 
 # The worker node groups for the cluster
 nodeGroups:
+  # names of node groups need to be a valid hostname, not an fqdn (e.g _ or . cannot be in the name)
   - # This group uses details found in nodeGroupDefault below
     # and is enabled by default
     name: default-md-0


### PR DESCRIPTION
For nodeGroups the name of the group cannot contain `_` or `.` otherwise the cluster will not recognise the node and won't add the new machines to the cluster. Added a note to the `flavors.yaml` file