### PR TITLE
BUG: Fix issue with registry mirror

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -144,7 +144,14 @@ clusterNetworking:
     nodeCidr: 192.168.128.0/17
 
 # Settings for registry mirrors
-registryMirrors: { docker.io: ["https://dockerhub.stfc.ac.uk"] }
+registryMirrors:
+  docker.io:
+     - https://dockerhub.stfc.ac.uk
+  # Upstream points these to their own mirror, null it out to prevent issues with private containers
+  ghcr.io: null
+  nvcr.io: null
+  quay.io: null
+  registry.k8s.io: null
 
 # Settings for the Kubernetes API server
 apiServer:


### PR DESCRIPTION
Upstream points to `ghcr.io`, `quay.io` etc using their own mirror which may cause issues with private containers. Setting the values for registry mirrors to `null` to not have a mirror for the registry.