### PR TITLE
ENH: Bump default Kubernetes image for CAPI clusters to the latest v1…

### DIFF
--- a/user-values.yaml
+++ b/user-values.yaml
@@ -25,9 +25,9 @@ controlPlane:
 # The Kubernetes version of the cluster
 # This should match the version of kubelet and kubeadm in the image
 # and will be automatically updated by us
-kubernetesVersion: "1.34.3"
+kubernetesVersion: "1.34.6"
 # The name of the image to use for cluster machines
-machineImage: "capi-ubuntu-2204-kube-v1.34.3"
+machineImage: "capi-ubuntu-2204-kube-v1.34.6"
 
 addons:
   # Monitoring sets up kube-prometheus-stack and loki-stack.


### PR DESCRIPTION
….34 release available.